### PR TITLE
fix: added missing apps.default_auto_field configuration

### DIFF
--- a/password_rotate/apps.py
+++ b/password_rotate/apps.py
@@ -3,6 +3,7 @@ from django.apps import AppConfig
 
 class PasswordRotateConfig(AppConfig):
     name = 'password_rotate'
+    default_auto_field = "django.db.models.BigAutoField"
 
     def ready(self):
         from . import signals


### PR DESCRIPTION
Hey !

I tried to integrate this package in my project, but was getting this when running makemigration:

```bash
Migrations for 'password_rotate':
  /usr/local/lib/python3.13/site-packages/password_rotate/migrations/0002_alter_passwordchange_id_alter_passwordhistory_id.py
    ~ Alter field id on passwordchange
    ~ Alter field id on passwordhistory
```

It's because third party packages are supposed to define `default_auto_field` on their appconfig (otherwise it can very depending on project settings).

Cheers !!