### PR TITLE
fix crash when running createsuperuser on django>=5.0

### DIFF
--- a/password_rotate/managers.py
+++ b/password_rotate/managers.py
@@ -1,3 +1,4 @@
+import django
 from django.db import models
 from django.contrib.auth.hashers import identify_hasher
 from django.conf import settings
@@ -37,8 +38,12 @@ class PasswordHistoryManager(models.Manager):
             result = False
         else:
             # deal with django's createsuperuser checking unsaved instances
-            if not user._is_pk_set():
+            has_pk = (
+                (user.pk is not None) if django.VERSION < (5, 2) else user._is_pk_set()
+            )
+            if not has_pk:
                 return True
+
             entries = self.filter(user=user).all()[: self.default_offset]
             for entry in entries:
                 hasher = identify_hasher(entry.password)

--- a/password_rotate/managers.py
+++ b/password_rotate/managers.py
@@ -36,7 +36,10 @@ class PasswordHistoryManager(models.Manager):
         if user.check_password(raw_password):
             result = False
         else:
-            entries = self.filter(user=user).all()[:self.default_offset]
+            # deal with django's createsuperuser checking unsaved instances
+            if not user._is_pk_set():
+                return True
+            entries = self.filter(user=user).all()[: self.default_offset]
             for entry in entries:
                 hasher = identify_hasher(entry.password)
                 if hasher.verify(raw_password, entry.password):

--- a/password_rotate/tests/test_util.py
+++ b/password_rotate/tests/test_util.py
@@ -4,12 +4,15 @@ from unittest import mock
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.hashers import identify_hasher
+from django.core.management import call_command
 from django.test import TestCase
 from django.utils import timezone
 from django.urls import reverse
 
 from password_rotate.models import PasswordChange, PasswordHistory
 from password_rotate.utils import PasswordChecker
+
+from .utils import mock_password_input, MockTTY
 
 
 def do_nothing(*args, **kwargs):
@@ -305,3 +308,17 @@ class PasswordSimilarityRatioTest(BaseTestCase):
 
         # There should be 2 rows
         self.assertEqual(PasswordHistory.objects.filter(user=user).count(), 2)
+
+
+class RegressionTestCase(TestCase):
+    @mock_password_input()
+    def test_createsuperuser_regression_dj50(self):
+        # note: mocktty and mock_password_input was copied from django's test suite
+        call_command(
+            "createsuperuser",
+            "--username",
+            "super",
+            "--email",
+            "root@example.com",
+            stdin=MockTTY(),
+        )

--- a/password_rotate/tests/utils.py
+++ b/password_rotate/tests/utils.py
@@ -1,0 +1,40 @@
+from django.contrib.auth.management.commands import createsuperuser
+
+
+def mock_password_input():
+    """
+    Decorator to temporarily replace input/getpass to allow interactive
+    createsuperuser.
+
+    Adapted/simplified from https://github.com/django/django/blob/5.2/tests/auth_tests/test_management.py#L45-L95
+    """
+
+    def inner(test_func):
+        def wrapper(*args):
+            class mock_getpass:
+                @staticmethod
+                def getpass(prompt=b"Password: ", stream=None):
+                    return "password"
+
+            old_getpass = createsuperuser.getpass
+            createsuperuser.getpass = mock_getpass
+            try:
+                test_func(*args)
+            finally:
+                createsuperuser.getpass = old_getpass
+
+        return wrapper
+
+    return inner
+
+
+class MockTTY:
+    """
+    A fake stdin object that pretends to be a TTY to be used in conjunction
+    with mock_inputs.
+
+    Copied from https://github.com/django/django/blob/5.2/tests/auth_tests/test_management.py#L98-L105
+    """
+
+    def isatty(self):
+        return True


### PR DESCRIPTION
Hey !

On Django 5.0+, password-rotate breaks the "createsuperuser" management command.

First commit it failing test (comes with a bit of boilerplate I didn't manage to simplify, it's copied from django's test suite) and  the second is the proposed fix. 

Cheers